### PR TITLE
DS-927: Add automated client build

### DIFF
--- a/.github/workflows/build-client.yaml
+++ b/.github/workflows/build-client.yaml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+  # Trigger by updates from other repos.
+  repository_dispatch:
+    types: [client-update]
+
   # Allow manual trigger.
   workflow_dispatch:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Automatically builds the client.
It's being pushed to `master` just like now, which might be a bit messy (also doesn't allow us to set PR/code check requirements on `master` because they'd prevent the push), but we can restructure the branches separately.

**Which issue(s) this PR fixes**
Closes https://portworx.atlassian.net/browse/DS-927

