### PR TITLE
Make automated workflow work with an elevated token

### DIFF
--- a/.github/workflows/build-client.yaml
+++ b/.github/workflows/build-client.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2.3.4
+      with:
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
     - name: Docker Login
       uses: docker/login-action@v1


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Clones the repo with an elevated token, so that we can set up PR requirements but not block automated commits.

*Background*:
If we want to set up branch protection rules that require PRs and approvals to merge into `master`, but at the same time not block the automated workflow updates (and not change the branch structure), we need to set up an actor who is allowed to bypass those checks in the settings (`pdsgithubautomation`), and use the actor's token to set up the repo in the workflow.
This gets used by the commit&push action down the line, which gets through the bypass rules.

