### PR TITLE
DS-2434: Redirect default branch for commit fetching

### DIFF
--- a/.github/workflows/build-client.yaml
+++ b/.github/workflows/build-client.yaml
@@ -37,7 +37,7 @@ jobs:
         API_SHA_SHORT=$(curl -s \
           --header "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
           -H 'Accept: application/vnd.github.v3+json' \
-          'https://api.github.com/repos/portworx/pds-api/branches/develop'  \
+          'https://api.github.com/repos/portworx/pds-api/branches/master'  \
           | jq -r '.commit.sha[:7]')
         echo "::set-output name=short-sha::${API_SHA_SHORT}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Points the branch at the new branch name.

Part of https://portworx.atlassian.net/browse/DS-2434
Will merge when the rename actually happens.
