### PR TITLE
DS-2797: Commit updates with signoff

### DIFF
--- a/.github/workflows/build-client.yaml
+++ b/.github/workflows/build-client.yaml
@@ -68,4 +68,5 @@ jobs:
         add: 'pds/'
         default_author: github_actions
         message: 'Update client for `${{ steps.latest-revision.outputs.short-sha }}`'
+        commit: --signoff
         push: true


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Makes the automated client updates from the bot be signed off.

I'm not sure how much this makes sense coming from a bot, but if that's the requirement :)

https://portworx.atlassian.net/browse/DS-2797

