### PR TITLE
Fixing client generation workflow

### DIFF
--- a/.github/workflows/build-client.yaml
+++ b/.github/workflows/build-client.yaml
@@ -25,6 +25,11 @@ jobs:
       with:
         token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
+    - name: Remove File
+      uses: JesseTG/rm@v1.0.0
+      with:
+        path: pds/
+
     - name: Docker Login
       uses: docker/login-action@v1
       with:


### PR DESCRIPTION
The generator only generates new files (and overwrites existing ones). If there are generated files that are no longer supposed to exist, they don't get cleaned up. 

For example:
1. Create a new endpoint with a new tag (e.g. tag1)
2. Generate the client (which creates api_tag1.go)
3. Change the tag (e.g. tag2)
4. Generate the client again (which creates api_tag2.go)
5. Now you have the duplicate code (e.g. api_tag1.go and api_tag2.go) and the client doesn't even compile.


This PR fixes that by always generating the client from scratch. 