### PR TITLE
New DCO validation

### DIFF
--- a/.github/workflows/dco-check.yaml
+++ b/.github/workflows/dco-check.yaml
@@ -1,0 +1,13 @@
+name: DCO Check
+
+on:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  DCO_Check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: DCO Check
+        uses: tisonkun/actions-dco@v1.1


### PR DESCRIPTION
The old DCO validation plugin was preventing our workflow from committing new client versions to master, even if they were signed. This new validation is only ran on PRs.